### PR TITLE
chore(sdk): Separate OIDC URL from completion.

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "experimental-oidc")]
+use std::collections::HashMap;
 use std::{fmt, sync::Arc};
 
 #[cfg(target_arch = "wasm32")]
@@ -450,6 +452,8 @@ impl ClientBuilder {
             root_span: self.root_span,
             #[cfg(feature = "experimental-oidc")]
             oidc_data: OnceCell::new(),
+            #[cfg(feature = "experimental-oidc")]
+            oidc_validation_data: RwLock::new(HashMap::new()),
         });
 
         debug!("Done building the Client");

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -453,7 +453,7 @@ impl ClientBuilder {
             #[cfg(feature = "experimental-oidc")]
             oidc_data: OnceCell::new(),
             #[cfg(feature = "experimental-oidc")]
-            oidc_validation_data: RwLock::new(HashMap::new()),
+            oidc_validation_data: Mutex::new(HashMap::new()),
         });
 
         debug!("Done building the Client");

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "experimental-oidc")]
+use std::collections::HashMap;
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug},
@@ -27,6 +29,8 @@ use async_once_cell::OnceCell;
 use dashmap::DashMap;
 use futures_core::Stream;
 use futures_util::StreamExt;
+#[cfg(feature = "experimental-oidc")]
+use mas_oidc_client::requests::authorization_code::AuthorizationValidationData;
 use matrix_sdk_base::{
     store::DynStateStore, BaseClient, RoomState, SendOutsideWasm, Session, SessionMeta,
     SessionTokens, SyncOutsideWasm,
@@ -196,6 +200,9 @@ pub(crate) struct ClientInner {
     /// The OpenID Connect data.
     #[cfg(feature = "experimental-oidc")]
     pub(crate) oidc_data: OnceCell<OidcData>,
+    /// The data needed to validate an OpenID Connect authorization request.
+    #[cfg(feature = "experimental-oidc")]
+    pub(crate) oidc_validation_data: RwLock<HashMap<String, AuthorizationValidationData>>,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -202,7 +202,7 @@ pub(crate) struct ClientInner {
     pub(crate) oidc_data: OnceCell<OidcData>,
     /// The data needed to validate an OpenID Connect authorization request.
     #[cfg(feature = "experimental-oidc")]
-    pub(crate) oidc_validation_data: RwLock<HashMap<String, AuthorizationValidationData>>,
+    pub(crate) oidc_validation_data: Mutex<HashMap<String, AuthorizationValidationData>>,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk/src/oidc.rs
+++ b/crates/matrix-sdk/src/oidc.rs
@@ -349,7 +349,9 @@ impl Oidc {
     }
 
     /// Get the URL that should be presented to authorize a given scope with the
-    /// Authorization Code flow.
+    /// Authorization Code flow. This URL should be presented to the user and
+    /// once a redirect is made to the redirect_uri, the authorization can be
+    /// finished by calling [`finish_authorization_with_authorization_code`].
     ///
     /// This should be used if a new scope is necessary to make a request.
     ///
@@ -368,6 +370,7 @@ impl Oidc {
     ///
     /// ```no_run
     /// use matrix_sdk::{Client, Error};
+    /// # use futures::executor::block_on;
     /// # use url::Url;
     /// # let homeserver = Url::parse("https://example.com").unwrap();
     /// # let redirect_uri = Url::parse("http://127.0.0.1/oidc").unwrap();
@@ -657,7 +660,9 @@ impl OidcLoginBuilder {
     }
 
     /// Get the URL that should be presented to login via the Authorization Code
-    /// flow.
+    /// flow. This URL should be presented to the user and once a redirect is
+    /// made to the redirect_uri, the login can be finished by calling
+    /// [`finish_login_with_authorization_code`].
     ///
     /// # Arguments
     ///
@@ -669,6 +674,7 @@ impl OidcLoginBuilder {
     ///
     /// ```no_run
     /// use matrix_sdk::{Client, Error};
+    /// # use futures::executor::block_on;
     /// # use url::Url;
     /// # let homeserver = Url::parse("https://example.com").unwrap();
     /// # let redirect_uri = Url::parse("http://127.0.0.1/oidc").unwrap();

--- a/crates/matrix-sdk/src/oidc.rs
+++ b/crates/matrix-sdk/src/oidc.rs
@@ -629,7 +629,7 @@ impl Oidc {
 /// OpenID Connect Provider via the Authorization Code flow.
 ///
 /// Created with [`Oidc::login`]. Finalized with
-/// [`.login_with_authorization_code()`](Self::login_with_authorization_code) or
+/// [`.finish_login_with_authorization_code()`](Self::finish_login_with_authorization_code) or
 /// [`.login_with_client_credentials()`](Self::login_with_client_credentials).
 #[allow(missing_debug_implementations)]
 pub struct OidcLoginBuilder {
@@ -690,7 +690,7 @@ impl OidcLoginBuilder {
     ///
     /// let _response = oidc
     ///     .login()
-    ///     .login_with_authorization_code(code, redirect_state)
+    ///     .finish_login_with_authorization_code(code, redirect_state)
     ///     .await?;
     ///
     /// // The access and refresh tokens can be persisted either from the response,
@@ -731,7 +731,7 @@ impl OidcLoginBuilder {
     ///
     /// [`ClientErrorCode`]: matrix_sdk::oidc::types::errors::ClientErrorCode
     #[instrument(target = "matrix_sdk::client", skip_all)]
-    pub async fn login_with_authorization_code(
+    pub async fn finish_login_with_authorization_code(
         &self,
         code: String,
         state: String,
@@ -759,7 +759,7 @@ impl OidcLoginBuilder {
     /// # let client = Client::new(homeserver).await?;
     /// let oidc = client.oidc();
     ///
-    /// let _response = oidc.login_with_authorization_code().await?;
+    /// let _response = oidc.login_with_client_credentials().await?;
     ///
     /// // The access and refresh tokens can be persisted either from the response,
     /// // or from one of the `Client::session_tokens*` methods.
@@ -791,7 +791,7 @@ pub(crate) struct OidcData {
 }
 
 /// The data needed to perform authorization using OpenID Connect.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OidcAuthorizationData {
     /// The URL that should be presented.
     pub url: Url,

--- a/crates/matrix-sdk/src/oidc.rs
+++ b/crates/matrix-sdk/src/oidc.rs
@@ -427,7 +427,7 @@ impl Oidc {
 
         let state = validation_data.state.clone();
 
-        self.client.inner.oidc_validation_data.write().await.insert(state.clone(), validation_data);
+        self.client.inner.oidc_validation_data.lock().await.insert(state.clone(), validation_data);
 
         Ok(OidcAuthorizationData { url, state })
     }
@@ -459,7 +459,7 @@ impl Oidc {
             .client
             .inner
             .oidc_validation_data
-            .write()
+            .lock()
             .await
             .remove(&state)
             .ok_or(OidcError::InvalidState)?;

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -224,7 +224,7 @@ impl OidcCli {
                 .client
                 .oidc()
                 .login()
-                .login_with_authorization_code(
+                .finish_login_with_authorization_code(
                     authorization_response.code,
                     authorization_response.state,
                 )


### PR DESCRIPTION
This PR splits up the OIDC auth when using a code into 2 steps. The first to get the URL and the second to perform the login using the code. The main driver for this has been that it would be nice to use OIDC through the FFI where we have no async support (or closure support). Having 2 separate methods makes the API much simpler with this restriction in place.